### PR TITLE
Put empty fontdata example between comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ return [
 					'orientation' => 'Landscape', // optional. This value will be ignored if format is a string value.
 					'options' => [
 						// mPDF Variables
-						'fontdata' => [
+						// 'fontdata' => [
 							// ... some fonts. http://mpdf1.com/manual/index.php?tid=454
-						]
+						// ]
 					]
 				],
 			]


### PR DESCRIPTION
This will avoid getting the "mPDF Error - Font is not supported - dejavusansmono" error when testing the extension from the sample code.